### PR TITLE
NumberFormatException when 

### DIFF
--- a/xunit-agent/src/main/java/se/capeit/dev/xunittestrunner/XUnitBuildProcess.java
+++ b/xunit-agent/src/main/java/se/capeit/dev/xunittestrunner/XUnitBuildProcess.java
@@ -47,6 +47,15 @@ class XUnitBuildProcess extends FutureBasedBuildProcess {
         processes.clear();
     }
 
+    private int tryParseInt(String stringValue, int defaultValue) {
+        try {
+            return Integer.parseInt(stringValue);
+        }
+        catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
     public BuildFinishedStatus call() throws Exception {
         try {
             String version = getParameter(StringConstants.ParameterName_XUnitVersion);
@@ -55,7 +64,7 @@ class XUnitBuildProcess extends FutureBasedBuildProcess {
             String platform = getParameter(StringConstants.ParameterName_Platform);
             logger.message("Runner parameters { Version = " + version + ", runtime = " + runtime + ", platform = " + platform + "}");
 
-            int numberOfParallelProcesses = Integer.parseInt(getParameter(StringConstants.ParameterName_NumberOfParallelProcesses));
+            int numberOfParallelProcesses = tryParseInt(getParameter(StringConstants.ParameterName_NumberOfParallelProcesses), 1);
             logger.message("Number of parallel processes is set to: " + numberOfParallelProcesses);
 
             File agentToolsDirectory = buildingAgent.getAgentConfiguration().getAgentToolsDirectory();


### PR DESCRIPTION
Given nothing was entered to the "Number of parallel running processes:" field of the xUnit Build Step form. When trying to run the build TeamCity is breaking with this exception:

```
java.lang.NumberFormatException: For input string: ""
	at java.lang.NumberFormatException.forInputString(Unknown Source)
	at java.lang.Integer.parseInt(Unknown Source)
	at java.lang.Integer.parseInt(Unknown Source)
	at se.capeit.dev.xunittestrunner.XUnitBuildProcess.call(XUnitBuildProcess.java:58)
	at se.capeit.dev.xunittestrunner.XUnitBuildProcess.call(XUnitBuildProcess.java:19)
	at java.util.concurrent.FutureTask.run(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.lang.Thread.run(Unknown Source)
````

FYI: as I don't have a Java setup running locally the commit is a blind fix. :-O So please check yourself again.